### PR TITLE
Make build.py launch a server and run sass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is the new GovLab website.
 
 * Python 2.7
 * [pip and virtualenv](http://stackoverflow.com/q/4324558)
+* [SASS](http://sass-lang.com/install)
 
 ## Quick Start
 
@@ -16,11 +17,11 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-To build the site and continuously rebuild it as you change the source,
-run `python build.py`.
+To develop the site, run `python build.py` and visit
+http://localhost:7000/. All static assets will be rebuilt as
+you change them.
 
-The `site` directory will contain the generated website files. You can
-run `python -m SimpleHTTPServer` in that directory for easy development.
+The `site` directory will contain the generated website files.
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the new GovLab website.
 
 * Python 2.7
 * [pip and virtualenv](http://stackoverflow.com/q/4324558)
-* [SASS](http://sass-lang.com/install)
+* [SASS](http://sass-lang.com/install) (Optional)
 
 ## Quick Start
 
@@ -19,7 +19,8 @@ pip install -r requirements.txt
 
 To develop the site, run `python build.py` and visit
 http://localhost:7000/. All static assets will be rebuilt as
-you change them.
+you change them. However, if `sass` isn't on your command-line,
+your SASS files won't be rebuilt.
 
 The `site` directory will contain the generated website files.
 

--- a/build.py
+++ b/build.py
@@ -29,6 +29,17 @@ _FUNDERS = path.join(getcwd(), 'data/funders.yaml')
 
 _SLUG = lambda x: slugify(unicode(unidecode(unicode(x).lower())) if x else u'')
 
+# http://stackoverflow.com/a/287944
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
 def filters():
     return {'slug': _SLUG}
 
@@ -109,7 +120,9 @@ def start_web_server():
         Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
         httpd = SocketServer.TCPServer(("", PORT), Handler)
 
-        print "Starting HTTP server at port %d." % PORT
+        print bcolors.BOLD + \
+              ("Starting HTTP server at port %d." % PORT) + \
+              bcolors.ENDC
         httpd.serve_forever()
 
     # We'd prefer to not have to change the directory of the current
@@ -125,15 +138,20 @@ def start_sass():
     src_path = path.join(_SASSPATH, 'styles.scss')
     dest_path = path.join(_SEARCHPATH, 'static', 'styles', 'styles.css')
 
-    print "Starting SASS."
+    print bcolors.BOLD + "Starting SASS." + bcolors.ENDC
 
-    process = subprocess.Popen([
-        'sass',
-        '--watch',
-        '%s:%s' % (src_path, dest_path)
-    ])
-    atexit.register(process.kill)
-
+    try:
+        process = subprocess.Popen([
+            'sass',
+            '--watch',
+            '%s:%s' % (src_path, dest_path)
+        ])
+        atexit.register(process.kill)
+    except OSError, e:
+        print bcolors.FAIL
+        print "SASS failure: %s" % e
+        print "SASS files will not be built."
+        print bcolors.ENDC
 
 if __name__ == '__main__':
     auto = _AUTO_RELOAD


### PR DESCRIPTION
This makes development easier by launching SASS and a web server as part of `build.py`.
